### PR TITLE
chat issue is resolved we can send template to client

### DIFF
--- a/client/src/pages/chat/Conversion.jsx
+++ b/client/src/pages/chat/Conversion.jsx
@@ -47,6 +47,7 @@ const AGENTS_LIST = [
 const Conversion = ({
    data,
    onSendMessage,
+   onSendTemplate,
    onBack,
    onToggleProfile,
    onClearChat,
@@ -164,9 +165,16 @@ const Conversion = ({
 
    const onEmojiClick = (emojiObject) => setInputText((prev) => prev + emojiObject.emoji);
 
-   const handleTemplateSelect = (template) => {
-      setInputText(template);
+   const handleQuickReplySelect = (text) => {
+      setInputText(text);
       setShowTemplates(false);
+   };
+
+   const handleTemplateSelect = async (template) => {
+      if (!template?.name || !onSendTemplate) return;
+      await onSendTemplate(template);
+      setShowTemplates(false);
+      setShowQuickReplies(false);
    };
 
    const handleFileChange = async (e) => {
@@ -496,7 +504,7 @@ const Conversion = ({
                      {displayQuickReplies.map((reply) => (
                         <div
                            key={reply._id}
-                           onClick={() => { handleTemplateSelect(reply.content); setShowQuickReplies(false); }}
+                           onClick={() => { handleQuickReplySelect(reply.content); setShowQuickReplies(false); }}
                            className="flex gap-3 p-3 hover:bg-slate-50 rounded-xl cursor-pointer transition-colors group border-l-2 border-l-transparent hover:border-l-[#22C55E]"
                         >
                            <div className="w-10 h-10 rounded-xl bg-green-50 text-[#22C55E] flex items-center justify-center shrink-0">
@@ -534,7 +542,7 @@ const Conversion = ({
                      {displayTemplates.map((template) => (
                         <div
                            key={template.id}
-                           onClick={() => { handleTemplateSelect(template.bodyText || template.content); setShowTemplates(false); }}
+                           onClick={() => { handleTemplateSelect(template); }}
                            className="flex gap-3 p-3 hover:bg-slate-50 rounded-xl cursor-pointer transition-colors group border-l-2 border-l-transparent hover:border-l-[#22C55E]"
                         >
                            <div className="w-10 h-10 rounded-xl bg-blue-50 text-blue-500 flex items-center justify-center shrink-0">

--- a/client/src/pages/chat/chat.jsx
+++ b/client/src/pages/chat/chat.jsx
@@ -449,6 +449,88 @@ const Chat = () => {
     }
   };
 
+  const handleSendTemplate = async (template) => {
+    if (!activeChatId || !template?.name) return;
+
+    const time = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    const tempId = 'temp_tpl_' + Date.now();
+
+    const tempMessage = {
+      _id: tempId,
+      chatId: activeChatId,
+      text: `Template: ${template.name}`,
+      sender: 'me',
+      time,
+      status: 'pending',
+      messageType: 'template',
+      createdAt: new Date()
+    };
+
+    const getBodyParamCount = (selectedTemplate) => {
+      const bodyComponent = Array.isArray(selectedTemplate?.components)
+        ? selectedTemplate.components.find((component) => String(component?.type || '').toUpperCase() === 'BODY')
+        : null;
+      const bodyText = bodyComponent?.text || '';
+      const placeholders = bodyText.match(/{{\d+}}/g) || [];
+      return new Set(placeholders).size;
+    };
+
+    const bodyParamCount = getBodyParamCount(template);
+    const fallbackParamText = activeChat?.name || 'there';
+    const components = bodyParamCount > 0
+      ? [{
+        type: 'body',
+        parameters: Array.from({ length: bodyParamCount }, () => ({
+          type: 'text',
+          text: fallbackParamText
+        }))
+      }]
+      : [];
+
+    setMessages((prev) => [...prev, tempMessage]);
+
+    try {
+      const result = await chatService.sendTemplateMessage(
+        activeChatId,
+        template.name,
+        template.language || 'en_US',
+        components
+      );
+
+      if (result.success) {
+        setSendError(null);
+        setMessages((prev) =>
+          prev.map((msg) => (msg._id === tempId ? { ...result.data, status: result.data.status || 'sent' } : msg))
+        );
+        socketRef.current?.emit('send_message', {
+          chatId: activeChatId,
+          message: result.data
+        });
+      } else {
+        const errMsg = result.error || `Failed to send template ${template.name}`;
+        const displayErr = result.errorCode ? `[${result.errorCode}] ${errMsg}` : errMsg;
+        setSendError(displayErr);
+        setTimeout(() => setSendError(null), 10000);
+        setMessages((prev) =>
+          prev.map((msg) =>
+            msg._id === tempId
+              ? result.data
+                ? { ...result.data, status: 'failed', error: errMsg }
+                : { ...msg, status: 'failed', error: errMsg }
+              : msg
+          )
+        );
+      }
+    } catch (error) {
+      const errMsg = error?.message || `Failed to send template ${template.name}`;
+      setSendError(errMsg);
+      setTimeout(() => setSendError(null), 10000);
+      setMessages((prev) =>
+        prev.map((msg) => (msg._id === tempId ? { ...msg, status: 'failed', error: errMsg } : msg))
+      );
+    }
+  };
+
   const handleCreateChat = async (name, phone) => {
     try {
       setLoading(true);
@@ -633,6 +715,7 @@ const Chat = () => {
               <Conversion
                 data={{ ...activeChat, messages: messages }}
                 onSendMessage={handleSendMessage}
+                onSendTemplate={handleSendTemplate}
                 onBack={() => setActiveChatId(null)}
                 onToggleProfile={() => setShowProfile(!showProfile)}
                 onClearChat={handleClearChat}

--- a/client/src/pages/chat/chat.jsx
+++ b/client/src/pages/chat/chat.jsx
@@ -8,6 +8,7 @@ import chatService from "../../services/chatService";
 import LabelApi from "../../services/LabelApi";
 import StatusApi from "../../services/StatusApi";
 import QuickReplyApi from "../../services/QuickReplyApi";
+import { fetchWhatsAppTemplates } from "../../services/TemplateApi";
 import io from "socket.io-client";
 import ErrorState from "../../components/ui/ErrorState";
 
@@ -157,11 +158,16 @@ const Chat = () => {
 
     // ── SOCKET: delivery / read status update ──────────────────────────
     socketRef.current.on("message_status_update", (data) => {
+      if (data.status === 'failed' && data.error) {
+        setSendError(data.errorCode ? `[${data.errorCode}] ${data.error}` : data.error);
+        setTimeout(() => setSendError(null), 10000);
+      }
+
       setMessages(prev =>
         prev.map(msg =>
           msg._id?.toString() === data.messageId?.toString() ||
             msg.whatsappMessageId === data.whatsappMessageId
-            ? { ...msg, status: data.status }
+            ? { ...msg, status: data.status, error: data.error || msg.error }
             : msg
         )
       );
@@ -322,6 +328,96 @@ const Chat = () => {
           message: result.data
         });
       } else {
+        // If first outbound message is outside the 24h window, initiate with a template.
+        if (!media && result.errorCode === 131047) {
+          console.warn('⏱️ 24h window expired. Trying template initiation flow...');
+
+          const templatesResponse = await fetchWhatsAppTemplates();
+          const approvedTemplates = Array.isArray(templatesResponse?.approvedTemplates)
+            ? templatesResponse.approvedTemplates
+            : Array.isArray(templatesResponse?.data?.data)
+              ? templatesResponse.data.data.filter((template) => template?.status === 'APPROVED')
+              : [];
+
+          const getBodyParamCount = (template) => {
+            const bodyComponent = Array.isArray(template?.components)
+              ? template.components.find((component) => String(component?.type || '').toUpperCase() === 'BODY')
+              : null;
+            const bodyText = bodyComponent?.text || '';
+            const placeholders = bodyText.match(/{{\d+}}/g) || [];
+            return new Set(placeholders).size;
+          };
+
+          const starterTemplate = approvedTemplates.find((template) => getBodyParamCount(template) === 0) || approvedTemplates[0];
+
+          if (!starterTemplate?.name) {
+            const noTemplateMsg = 'No approved WhatsApp templates are available. Create or approve a template in Meta first, then send it to start the conversation.';
+            setSendError(noTemplateMsg);
+            setTimeout(() => setSendError(null), 10000);
+            setMessages((prev) =>
+              prev.map(msg =>
+                msg._id === tempId ? { ...msg, status: 'failed', error: noTemplateMsg } : msg
+              )
+            );
+            return;
+          }
+
+          const bodyParamCount = getBodyParamCount(starterTemplate);
+          const fallbackParamText = activeChat?.name || 'there';
+          const starterComponents = bodyParamCount > 0
+            ? [{
+              type: 'body',
+              parameters: Array.from({ length: bodyParamCount }, () => ({
+                type: 'text',
+                text: fallbackParamText
+              }))
+            }]
+            : [];
+
+          const templateResult = await chatService.sendTemplateMessage(
+            activeChatId,
+            starterTemplate.name,
+            starterTemplate.language || 'en_US',
+            starterComponents
+          );
+
+          if (templateResult.success) {
+            console.log('✅ Template sent for conversation initiation');
+            const infoMsg = 'Starter template sent. Ask the user to reply once, then you can send normal messages for 24 hours.';
+            setSendError(infoMsg);
+            setTimeout(() => setSendError(null), 10000);
+            setMessages((prev) =>
+              prev.map(msg =>
+                msg._id === tempId
+                  ? templateResult.data
+                    ? { ...templateResult.data, status: templateResult.data.status || 'sent' }
+                    : { ...msg, status: 'sent', text: 'Template sent to initiate conversation' }
+                  : msg
+              )
+            );
+
+            if (templateResult.data) {
+              socketRef.current?.emit("send_message", {
+                chatId: activeChatId,
+                message: templateResult.data
+              });
+            }
+
+            return;
+          }
+
+          const tplErr = templateResult.error || `Could not send starter template. Ensure ${starterTemplate.name} is approved in Meta.`;
+          const tplDisplay = templateResult.errorCode ? `[${templateResult.errorCode}] ${tplErr}` : tplErr;
+          setSendError(tplDisplay);
+          setTimeout(() => setSendError(null), 10000);
+          setMessages((prev) =>
+            prev.map(msg =>
+              msg._id === tempId ? { ...msg, status: 'failed', error: tplErr } : msg
+            )
+          );
+          return;
+        }
+
         console.error('❌ Failed to send message:', result.error, 'Code:', result.errorCode);
         // Show WhatsApp error to user (include error code if available)
         const errMsg = result.error || 'Failed to send message via WhatsApp';

--- a/client/src/services/chatService.js
+++ b/client/src/services/chatService.js
@@ -161,7 +161,7 @@ const chatService = {
    */
   async sendTemplateMessage(chatId, templateName, languageCode = 'en', components = []) {
     try {
-      const response = await axios.post('/whatsapp/send-template', {
+      const response = await axios.post('/chats/send-template', {
         chatId,
         templateName,
         languageCode,
@@ -173,10 +173,14 @@ const chatService = {
         data: response.data.data || response.data
       };
     } catch (error) {
-      console.error('Error sending template:', error);
+      const serverData = error.response?.data;
+      console.error('Error sending template:', serverData || error.message);
       return {
         success: false,
-        error: error.response?.data?.error || error.message
+        error: serverData?.error || error.message,
+        errorCode: serverData?.errorCode,
+        details: serverData?.rawError,
+        data: serverData?.data
       };
     }
   },

--- a/server/controllers/whatsappController.js
+++ b/server/controllers/whatsappController.js
@@ -3,6 +3,7 @@ const Chat = require('../models/Chat');
 const Message = require('../models/Message');
 const { getIO } = require('../config/socket');
 const { normalizePhoneNumber } = require('../utils/phoneHelper');
+const { hasActiveCustomerWindow } = require('../utils/conversationWindow');
 
 /**
  * WhatsApp Webhook Controller
@@ -310,6 +311,7 @@ async function handleIncomingMessage(data) {
       }
       chat.status = 'active';
       chat.lastActivity = new Date();
+      chat.lastInboundAt = new Date(parseInt(timestamp) * 1000);
       // Ensure whatsappId is set (for older chats)
       if (!chat.whatsappId) {
         chat.whatsappId = from;
@@ -435,6 +437,7 @@ async function handleIncomingMessage(data) {
     chat.lastMsg = messageText;
     chat.lastMsgTime = newMessage.time;
     chat.unread = (chat.unread || 0) + 1;
+    chat.lastInboundAt = new Date(parseInt(timestamp) * 1000);
     await chat.save();
 
     // Emit to socket for real-time update
@@ -468,18 +471,28 @@ async function handleIncomingMessage(data) {
  */
 async function handleStatusUpdate(data) {
   try {
-    const { messageId, status, timestamp, recipientId } = data;
+    const { messageId, status, timestamp, recipientId, errors } = data;
+
+    const firstError = Array.isArray(errors) && errors.length > 0 ? errors[0] : null;
+    const errorCode = firstError?.code;
+    const errorMessage = firstError?.title || firstError?.message || firstError?.details || null;
 
     console.log(`📊 Processing status update: ${status} for message ${messageId}`);
     console.log(`   Recipient: ${recipientId}, Time: ${new Date(parseInt(timestamp) * 1000).toISOString()}`);
 
     // Update message status in database
+    const updatePayload = {
+      status: status,
+      statusTimestamp: new Date(parseInt(timestamp) * 1000)
+    };
+
+    if (status === 'failed' && errorMessage) {
+      updatePayload.error = errorCode ? `[${errorCode}] ${errorMessage}` : errorMessage;
+    }
+
     const message = await Message.findOneAndUpdate(
       { whatsappMessageId: messageId },
-      { 
-        status: status,
-        statusTimestamp: new Date(parseInt(timestamp) * 1000)
-      },
+      updatePayload,
       { new: true }
     );
 
@@ -493,7 +506,9 @@ async function handleStatusUpdate(data) {
           io.emit('message_status_update', {
             messageId: message._id,
             status: status,
-            whatsappMessageId: messageId
+            whatsappMessageId: messageId,
+            error: message.error,
+            errorCode: errorCode
           });
           console.log(`📡 Status update emitted to frontend`);
         }
@@ -531,6 +546,15 @@ exports.sendWhatsAppMessage = async (req, res, next) => {
       return res.status(404).json({
         success: false,
         message: 'Chat not found'
+      });
+    }
+
+    const canSendFreeText = await hasActiveCustomerWindow(chat);
+    if (!canSendFreeText) {
+      return res.status(500).json({
+        success: false,
+        message: '24-hour window expired — the contact must message you first, then you can reply within 24 hours. Use an approved template message to initiate.',
+        errorCode: 131047
       });
     }
 

--- a/server/models/Chat.js
+++ b/server/models/Chat.js
@@ -21,6 +21,7 @@ const chatSchema = mongoose.Schema(
       enum: ["whatsapp", "web", "api", "manual"],
       default: "whatsapp"
     },
+    lastInboundAt: { type: Date },
     businessProfile: {
       description: String,
       email: String,
@@ -34,6 +35,19 @@ const chatSchema = mongoose.Schema(
   },
   { timestamps: true }
 );
+
+chatSchema.set('toJSON', { virtuals: true });
+chatSchema.set('toObject', { virtuals: true });
+
+chatSchema.virtual('replyWindowExpiresAt').get(function () {
+  if (!this.lastInboundAt) return null;
+  return new Date(this.lastInboundAt.getTime() + 24 * 60 * 60 * 1000);
+});
+
+chatSchema.virtual('canSendFreeText').get(function () {
+  if (!this.lastInboundAt) return false;
+  return Date.now() - new Date(this.lastInboundAt).getTime() < 24 * 60 * 60 * 1000;
+});
 
 // Index for faster queries
 // Note: phone and whatsappId already have indexes from unique: true

--- a/server/routes/chatRoutes.js
+++ b/server/routes/chatRoutes.js
@@ -10,6 +10,7 @@ const upload = require('../middleware/upload');
 const path = require('path');
 const fs = require('fs');
 const { normalizePhoneNumber } = require('../utils/phoneHelper');
+const { hasActiveCustomerWindow } = require('../utils/conversationWindow');
 const router = express.Router();
 
 /**
@@ -249,6 +250,16 @@ router.post("/message", async (req, res) => {
       let displayText = text;
       let whatsappError = null;
 
+      const canSendFreeText = await hasActiveCustomerWindow(chat);
+
+      if (!canSendFreeText && (text?.trim() || media)) {
+        return res.status(500).json({
+          success: false,
+          error: '24-hour window expired — the contact must message you first, then you can reply within 24 hours. Use an approved template message to initiate.',
+          errorCode: 131047
+        });
+      }
+
       console.log(`📱 Sending WhatsApp message via recipient: ${whatsappRecipient} (whatsappId: ${chat.whatsappId}, phone: ${chat.phone})`);
 
       // Handle media messages
@@ -439,7 +450,11 @@ router.post("/message", async (req, res) => {
       lastActivity: new Date()
     };
     if (sender === "them") {
-      await Chat.findByIdAndUpdate(chatId, { ...chatUpdate, $inc: { unread: 1 } });
+      await Chat.findByIdAndUpdate(chatId, {
+        ...chatUpdate,
+        lastInboundAt: new Date(),
+        $inc: { unread: 1 }
+      });
     } else {
       await Chat.findByIdAndUpdate(chatId, chatUpdate);
     }
@@ -621,9 +636,12 @@ router.post("/send-template", async (req, res) => {
     );
 
     if (!result.success) {
+      const { code, userMessage } = parseWhatsAppError(result.error);
       return res.status(500).json({
-        error: "Failed to send template",
-        details: result.error
+        success: false,
+        error: userMessage || "Failed to send template",
+        errorCode: code,
+        rawError: result.error
       });
     }
 

--- a/server/utils/conversationWindow.js
+++ b/server/utils/conversationWindow.js
@@ -1,0 +1,38 @@
+const Message = require('../models/Message');
+
+const CUSTOMER_SERVICE_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+async function getLastInboundAt(chat) {
+  if (!chat?._id) return null;
+
+  if (chat.lastInboundAt) {
+    return new Date(chat.lastInboundAt);
+  }
+
+  const latestInbound = await Message.findOne({
+    chatId: chat._id,
+    sender: 'them',
+    isDeleted: false
+  })
+    .sort({ createdAt: -1 })
+    .select('createdAt')
+    .lean();
+
+  return latestInbound?.createdAt ? new Date(latestInbound.createdAt) : null;
+}
+
+async function hasActiveCustomerWindow(chat, now = new Date()) {
+  const lastInboundAt = await getLastInboundAt(chat);
+
+  if (!lastInboundAt) {
+    return false;
+  }
+
+  return now.getTime() - lastInboundAt.getTime() < CUSTOMER_SERVICE_WINDOW_MS;
+}
+
+module.exports = {
+  CUSTOMER_SERVICE_WINDOW_MS,
+  getLastInboundAt,
+  hasActiveCustomerWindow
+};


### PR DESCRIPTION

[conversationWindow.js](vscode-file://vscode-app/c:/Users/Hitesh%20sharma/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Extended chat model with inbound-window state:
[Chat.js](vscode-file://vscode-app/c:/Users/Hitesh%20sharma/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Enforced window check before outbound WhatsApp send in chat route:
[chatRoutes.js](vscode-file://vscode-app/c:/Users/Hitesh%20sharma/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Updated webhook flow to store inbound timestamp from customer messages:
[whatsappController.js](vscode-file://vscode-app/c:/Users/Hitesh%20sharma/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Updated frontend fallback logic to fetch approved templates and auto-pass parameters:
[chat.jsx](vscode-file://vscode-app/c:/Users/Hitesh%20sharma/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Template send endpoint wiring used in chat service:
[chatService.js](vscode-file://vscode-app/c:/Users/Hitesh%20sharma/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[TemplateApi.js](vscode-file://vscode-app/c:/Users/Hitesh%20sharma/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Acceptance Criteria

If no inbound user reply in last 24h, normal message returns 131047 and app sends approved template fallback.
Template fallback must not fail with 132000 due to missing body params.
After customer replies, normal free-form message send succeeds.
Chat state persists and reflects inbound-driven window behavior.

Remaining Operational Requirement

Meta webhook delivery must work correctly. If inbound webhook is not received, window will never open for simple chat even after user replies.

UAT Test Cases

New contact, no previous inbound:
Send normal text → expect template fallback.
Same contact replies from WhatsApp:
Send normal text again → expect success.
Approved template with one placeholder:
Fallback send → expect success (no 132000).
After 24h timeout:
Send normal text → expect 131047 and template-only initiation again.
